### PR TITLE
Add support for Kerberos authentication to HTTP proxy.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ http.get(opts, function (res) {
   console.log('"response" event!', res.headers);
   res.pipe(process.stdout);
 });
+
+// To use authentication you can pass the auth paramter to the constructor
+// or set use_kerberos to use Kerberos/GSSAPI authentication to the proxy
+// for example to enable kerberos:
+var agent = new HttpProxyAgent(proxy);
+proxy.use_kerberos = true;
+
 ```
 
 

--- a/package.json
+++ b/package.json
@@ -23,8 +23,11 @@
   },
   "dependencies": {
     "agent-base": "2",
-    "extend": "3",
-    "debug": "2"
+    "debug": "2",
+    "extend": "3"
+  },
+  "optionalDependencies": {
+    "kerberos": "~0.0.17"
   },
   "devDependencies": {
     "mocha": "2",


### PR DESCRIPTION
This would add support for GSSAPI/Kerberos authentication for the proxy.  Many corporate environments use Kerberos for authentication and it would be most helpful if node-http-proxy-agent supported it.  

Add test case as well and optional dependency.

Signed-off-by: Rusty Conover rusty@twosigma.com
