### PR TITLE
Add defaultPort field to the HttpProxyAgent

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,6 +48,7 @@ function HttpProxyAgent (opts) {
   }
 
   this.proxy = proxy;
+  this.defaultPort = 80;
 }
 inherits(HttpProxyAgent, Agent);
 


### PR DESCRIPTION
This adds a `defaultPort` field to every instance of the `HttpProxyAgent` so that Node's internal `http.request` does not add the `:80` port to the `Host` header.

For further details, please refer to [this similar pull request](https://github.com/TooTallNate/node-https-proxy-agent/pull/43).