### PR TITLE
CI - run using Node.js 14.x and 16.x as well

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node-version: [6.x, 8.x, 10.x, 12.x]
+        node-version: [6.x, 8.x, 10.x, 12.x, 14.x, 16.x]
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
Add Node.js' LTS and current versions.